### PR TITLE
sm8350-common: Compile kernel with Clang 14.0.6

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -97,6 +97,7 @@ BOARD_MKBOOTIMG_ARGS += --header_version $(BOARD_BOOT_HEADER_VERSION)
 TARGET_KERNEL_ADDITIONAL_FLAGS := DTC_EXT=$(shell pwd)/prebuilts/misc/linux-x86/dtc/dtc LLVM=1
 TARGET_KERNEL_CLANG_COMPILE := true
 
+TARGET_KERNEL_CLANG_VERSION := r450784d
 BOARD_KERNEL_CMDLINE += androidboot.console=ttyMSM0
 BOARD_KERNEL_CMDLINE += androidboot.hardware=qcom
 BOARD_KERNEL_CMDLINE += androidboot.memcg=1

--- a/vendorsetup.sh
+++ b/vendorsetup.sh
@@ -1,0 +1,11 @@
+CLANGDIR=$PWD/prebuilts/clang/host/linux-x86
+ if [ ! -d "${CLANGDIR}/clang-r450784d" ]
+ then
+     GREEN='\033[0;32m'
+     NC='\033[0m'
+     echo -e "${GREEN}Downloading clang 14.0.6${NC}"
+     mkdir ${CLANGDIR}/clang-r450784d
+     wget https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/refs/tags/android-13.0.0_r3/clang-r450784d.tar.gz -P ${CLANGDIR}
+     tar -C "${CLANGDIR}"/clang-r450784d/ -zxf "${CLANGDIR}"/clang-r450784d.tar.gz
+     rm ${CLANGDIR}/clang-r450784d.tar.gz
+ fi


### PR DESCRIPTION
* Use latest available version (https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+/refs/tags/android-13.0.0_r3/clang-r450784d/)


Co-authored-by: Joey Huab <joey@evolution-x.org>